### PR TITLE
Fix: Linear level scale, enhance OSC feedback debugging

### DIFF
--- a/mock_api.go
+++ b/mock_api.go
@@ -92,9 +92,9 @@ func main() {
 
 					err = replyClient.Send(replyMsg)
 					if err != nil {
-						log.Printf("Mock OSC: Error sending reply to %s on path %s: %v\n", returnURL, replyPath, err)
+						log.Printf("Mock OSC: Error sending reply to %s (target %s:%d) on path %s: %v\n", returnURL, host, port, replyPath, err)
 					} else {
-						fmt.Printf("Mock OSC: Sent reply to %s path %s with value %f for loop %d\n", returnURL, replyPath, valueToReturn, loopID_1based)
+						fmt.Printf("Mock OSC: Sent reply to %s (target %s:%d) path %s with value %f for loop %d\n", returnURL, host, port, replyPath, valueToReturn, loopID_1based)
 					}
 
 				} else {


### PR DESCRIPTION
This commit addresses two main issues:
1. The "Level" control slider in `sooperGUI.go` was using an exponential scale, causing large jumps in value. It has been changed to a linear scale.
2. To help diagnose missing feedback for the custom level control, enhanced OSC logging has been added to both applications.

Key Changes:

sooperGUI.go:
- Level Control Scale:
  - Changed the calculation of the 'wet' value in the mouse event handler for the "Level" column to be linear with respect to the mouse position ('fill').
  - The 'wet' value is now `fill * 0.921` (and clamped), providing a direct linear mapping up to the maximum of 0.921.
- OSC Debugging:
  - Added a verbose log statement in the main OSC dispatcher (`dispatcher.AddMsgHandler("*", ...)`) to print the address and arguments of *every* incoming OSC message before any further processing. This will help confirm if replies from the mock API (or SooperLooper) are reaching the GUI's listener.

mock_api.go:
- OSC Debugging:
  - Enhanced logging when the mock API sends a reply to a `/get_strip_gain` request. The log now includes the exact destination host, port, OSC address, and value being sent.

These changes aim to make the level control more intuitive and provide better diagnostic information for troubleshooting the OSC feedback loop for the custom `/strip/...` gain parameter.