### PR TITLE
The verbose OSC logging in sooperGUI.go now uses infoLog and should b…

### DIFF
--- a/sooperGUI.go
+++ b/sooperGUI.go
@@ -259,9 +259,10 @@ Options:
 	// Add a message handler for all incoming OSC messages ("*").
 	// The handler is an anonymous function (a closure) that takes an *osc.Message.
 	dispatcher.AddMsgHandler("*", func(msg *osc.Message) {
-		// Log ALL incoming messages unconditionally before further processing to aid feedback debugging.
+		// Log ALL incoming messages unconditionally before further processing to aid feedback debugging,
+		// using infoLog so it's correctly redirected if running in 'st'.
 		// This will show if replies from mock_api.go are reaching this listener.
-		log.Printf("VERBOSE OSC IN (Main Dispatcher): Address: %s, Arguments: %v", msg.Address, msg.Arguments)
+		infoLog.Printf("VERBOSE OSC IN (Main Dispatcher): Address: %s, Arguments: %v", msg.Address, msg.Arguments)
 
 		// If the debug flag is enabled, log the incoming message (this is now somewhat redundant but kept for consistency).
 		// *debugFlag dereferences the pointer to get the boolean value.


### PR DESCRIPTION
…e directed to the correct terminal.

The application state is:

sooperGUI.go:
Level control uses a linear scale.
Sends OSC messages for level changes to /strip/Sooper<ID>/Gain/Gain%20(dB) on localhost:9090 (to mockClient). Polls for this value by sending /get_strip_gain to localhost:9090 (mockClient). Listens on its main OSC port (e.g., 9951) for incoming messages on /strip/Sooper<ID>/Gain/Gain (dB) to update the "Level" display. Includes verbose logging for all incoming OSC messages on its main listener, directed to infoLog. st terminal launch is active.
mock_api.go:
Listens on localhost:9090.
Handles messages to /strip/Sooper<ID>/Gain/Gain%20(dB) to log them. Handles messages to /get_strip_gain and sends a reply message (with value 0.75) to sooperGUI.go's main listener, using the path /strip/Sooper<ID>/Gain/Gain (dB). Includes enhanced logging for sent replies.
This setup should now correctly handle the linear scale and provide better logging to diagnose the feedback loop. If feedback is still not observed in the GUI for the "Level" column (i.e., it doesn't update to 0.75 after polling), the "VERBOSE OSC IN (Main Dispatcher)" logs in the original terminal (where sooperGUI.go was started before it launched st) will be key to see if the replies from mock_api.go are arriving.